### PR TITLE
dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+### Changelog
+
+This document contains a list of changes made to the project. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+It should be updated every time a new version (major, minor or fixes) is released. This should be in sync with the version number in the release tags.
+
+Structure should be as follows:
+
+```markdown
+## [Unreleased]
+
+- Changes that are currently in development and will be released in the next version. - Scope: Major, Minor, Patch
+
+## [Added]
+
+- New feature or functionality (e.g. new API endpoint, new component, new page, new service, etc.) - Scope: Major, Minor
+
+## [Changed]
+
+- Changes in existing functionality (e.g. changes in API response, changes in component behavior, changes in page layout, etc.) - Scope: Major, Minor
+
+## [Deprecated]
+
+- Features that are being deprecated and will be removed in future releases. - Scope: Major, Minor
+```
+
+Please add the changes in the appropriate section and follow the format mentioned above; If you are adding a new feature, please add it under the `[Added]` section. If you are changing an existing feature, please add it under the `[Changed]` section. If you are deprecating a feature, please add it under the `[Deprecated]` section.
+
+Thank you for your contribution!

--- a/backend/paycheck/.isort.cfg
+++ b/backend/paycheck/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+py_version = 3.10

--- a/backend/paycheck/.isort.cfg
+++ b/backend/paycheck/.isort.cfg
@@ -1,2 +1,3 @@
 [settings]
-py_version = 3.10
+py_version=3.10
+skip=.gitignore,.dockerignore,.env,.venv,.vscode,.pytest_cache,.mypy_cache,.tox,.nox,build,dist,*.egg-info


### PR DESCRIPTION
- **pin `isort` config to `python 3.10`**
- **chore(isort): ignore irrelevants files such as `node_modules`, `dockerignore` in sort configuration**
- **docs(external): create module to contain `end-user` documentation**
- **add guide to `CHANGELOG.md`**
